### PR TITLE
Ensure GitHub Actions with required checks run on external PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,13 @@
 name: CI
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 0 * * TUE"
 jobs:
   build:
     name: Build

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -1,5 +1,13 @@
 name: Documentation
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 0 * * TUE"
 jobs:
   rustdoc:
     name: Build Rust API docs


### PR DESCRIPTION
Only run workflows on pushes to master or PRs to master.
Also run workflows on  a schedule every Tuesday at midnight.