### PR TITLE
Add audit workflow and cargo-deny configuration

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,46 @@
+name: Audit
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 0 * * TUE"
+jobs:
+  rust:
+    name: Audit Rust Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Fetch cargo-audit
+        run: |
+          curl -sL "$RELEASE" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
+        env:
+          RELEASE: "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.6.6/cargo-deny-0.6.6-x86_64-unknown-linux-musl.tar.gz"
+
+      - name: Run cargo-deny
+        run: cargo-deny check
+
+  js:
+    name: Audit JS Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Node toolchain
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+
+      - name: Install Nodejs toolchain
+        run: yarn install --frozen-lockfile
+
+      - name: Yarn audit
+        run: yarn audit

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,30 @@
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+notice = "warn"
+ignore = []
+
+[licenses]
+unlicensed = "deny"
+allow = [
+  "MIT"
+]
+deny = []
+copyleft = "deny"
+allow-osi-fsf-free = "neither"
+default = "deny"
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "deny"
+highlight = "all"
+allow = []
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = [] # This crate has no dependencies
+allow-git = []


### PR DESCRIPTION
This is expected to be a noop since `bubblebabble` has no dependencies.