### PR TITLE
Add bench workflow and benchmarks for encode and decode performance

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -1,0 +1,36 @@
+name: Bench
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 0 * * TUE"
+jobs:
+  bench:
+    name: Bench
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: Compile
+        run: cargo build --verbose
+
+      - name: Compile tests
+        run: cargo bench --no-run
+
+      - name: Test
+        run: cargo bench

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,0 +1,36 @@
+#![feature(test)]
+extern crate test;
+
+mod encode {
+    #[bench]
+    fn benchmark_encode_empty(b: &mut ::test::Bencher) {
+        b.iter(|| bubblebabble::encode([]))
+    }
+
+    #[bench]
+    fn benchmark_encode_vector_1234567890(b: &mut ::test::Bencher) {
+        b.iter(|| bubblebabble::encode("1234567890"))
+    }
+
+    #[bench]
+    fn benchmark_encode_vector_pineapple(b: &mut ::test::Bencher) {
+        b.iter(|| bubblebabble::encode("Pineapple"))
+    }
+}
+
+mod decode {
+    #[bench]
+    fn benchmark_decode_empty(b: &mut ::test::Bencher) {
+        b.iter(|| bubblebabble::decode("xexax"))
+    }
+
+    #[bench]
+    fn benchmark_decode_vector_1234567890(b: &mut ::test::Bencher) {
+        b.iter(|| bubblebabble::decode("xesef-disof-gytuf-katof-movif-baxux"))
+    }
+
+    #[bench]
+    fn benchmark_decode_vector_pineapple(b: &mut ::test::Bencher) {
+        b.iter(|| bubblebabble::decode("xigak-nyryk-humil-bosek-sonax"))
+    }
+}


### PR DESCRIPTION
Performance today:

```
running 6 tests
test decode::benchmark_decode_empty             ... bench:          17 ns/iter (+/- 4)
test decode::benchmark_decode_vector_1234567890 ... bench:         310 ns/iter (+/- 106)
test decode::benchmark_decode_vector_pineapple  ... bench:         284 ns/iter (+/- 46)
test encode::benchmark_encode_empty             ... bench:         144 ns/iter (+/- 31)
test encode::benchmark_encode_vector_1234567890 ... bench:         424 ns/iter (+/- 130)
test encode::benchmark_encode_vector_pineapple  ... bench:         343 ns/iter (+/- 123)
```