### PR TITLE
Use memchr accelerated find_byte to scan for matching vowels and consonants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ keywords = ["encoding", "bubblebabble"]
 categories = ["encoding"]
 
 [dependencies]
+bstr = { version = "0.2", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -26,5 +26,7 @@ skip-tree = []
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-registry = [] # This crate has no dependencies
+allow-registry = [
+  "https://github.com/rust-lang/crates.io-index",
+]
 allow-git = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,11 +60,8 @@ use std::convert::TryFrom;
 use std::error;
 use std::fmt;
 
-const VOWELS: &[u8] = &[b'a', b'e', b'i', b'o', b'u', b'y'];
-const CONSONANTS: &[u8] = &[
-    b'b', b'c', b'd', b'f', b'g', b'h', b'k', b'l', b'm', b'n', b'p', b'r', b's', b't', b'v', b'z',
-    b'x',
-];
+const VOWELS: [u8; 6] = *b"aeiouy";
+const CONSONANTS: [u8; 17] = *b"bcdfghklmnprstvzx";
 
 const HEADER: char = 'x';
 const TRAILER: char = 'x';

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
+#![allow(clippy::cast_possible_truncation)]
 #![deny(clippy::cargo)]
 #![deny(missing_docs, intra_doc_link_resolution_failure)]
 #![warn(rust_2018_idioms)]
@@ -221,7 +222,7 @@ pub fn decode<T: AsRef<str>>(encoded: T) -> Result<Vec<u8>, DecodeError> {
         }
         Ok(decoded)
     } else {
-        return Err(DecodeError::Corrupted);
+        Err(DecodeError::Corrupted)
     }
 }
 


### PR DESCRIPTION
This PR adds `bstr` as a dependency to get access to high-quality byte manipulation routines.

Depending on `bstr` makes sense given that this crate's intended consumer is `artichoke-backend`  to
implement the `digest` stdlib module. In this context, `bstr` is an acceptable dependency to take since `artichoke-backend` already depends on `bstr`, and likely will continue to depend on `bstr`.

This PR uses `bstr::ByteSlice::find_byte` instead of `iter().position(...)` on the `VOWELS` and `CONSONANTS` arrays. `find_byte` uses a SIMD accelerated `memchr` routine and is much faster.

The API also carries more semantic meaning than what it replaces.

This PR also cleans up some of the decoder logic to use slice patterns where possible.

This PR removes some uses of `u8::try_from` and replaces them with `as` casts since indexes on the `VOWELS` and `CONSONANTS` array are known to be less than `u8::MAX`.