### PR TITLE
Project polish for upcoming release on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,19 @@
 [package]
 name = "bubblebabble"
-version = "2.0.0"
+version = "2.0.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
-edition = "2018"
-description = "Rust implementation of the Bubble Babble binary data encoding"
-repository = "https://github.com/artichoke/bubblebabble"
-readme = "README.md"
 license = "MIT"
-keywords = ["encoding", "bubblebabble"]
+edition = "2018"
+readme = "README.md"
+repository = "https://github.com/artichoke/bubblebabble"
+homepage = "https://github.com/artichoke/bubblebabble"
+description = "Encoder and decoder for the Bubble Babble binary data encoding"
+keywords = ["encode", "decode", "utf8", "bubblebabble"]
 categories = ["encoding"]
 
 [dependencies]
 bstr = { version = "0.2", default-features = false }
+
+[dev-dependencies]
+doc-comment = "0.3"
+version-sync = "0.8"

--- a/README.md
+++ b/README.md
@@ -4,44 +4,51 @@
 [![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
 [![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
 <br>
-[![Documentation](https://img.shields.io/badge/docs-bubblebabble-blue.svg)](https://artichoke.github.io/bubblebabble/bubblebabble)
+[![API master](https://img.shields.io/badge/docs-master-blue.svg)](https://artichoke.github.io/bubblebabble/bubblebabble/)
 
-`bubblebabble` is a Rust implementation of the
-[Bubble Babble binary data encoding](https://github.com/artichoke/bubblebabble/blob/master/spec/Bubble_Babble_Encoding.txt).
+Implements the the
+[Bubble Babble binary data encoding](/spec/Bubble_Babble_Encoding.txt).
 
-The spec defines the following test vectors:
+> The Bubble Babble Encoding encodes arbitrary binary data into pseudowords that
+> are more natural to humans and that can be pronounced relatively easily.
 
-```rust
-assert_eq!(
-    bubblebabble::encode(&[]),
-    String::from("xexax")
-);
-assert_eq!(
-    bubblebabble::encode(&b"1234567890"[..]),
-    String::from("xesef-disof-gytuf-katof-movif-baxux")
-);
-assert_eq!(
-    bubblebabble::encode(&b"Pineapple"[..]),
-    String::from("xigak-nyryk-humil-bosek-sonax")
-);
+Bubble Babble encodes 6 characters in 16 bits and includes a checksum embedded
+in the encoded data. See the
+[Bubble Babble spec](/spec/Bubble_Babble_Encoding.txt).
+
+This crate depends on [bstr](https://crates.io/crates/bstr).
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+bubblebabble = "2"
 ```
 
-`bubblebabble` supports decoding to a byte vector:
+Then encode and decode data like:
 
 ```rust
-assert_eq!(
-    bubblebabble::decode("xexax"),
-    Ok(vec![])
-);
-assert_eq!(
-    bubblebabble::decode("xesef-disof-gytuf-katof-movif-baxux"),
-    Ok(Vec::from(&b"1234567890"[..]))
-);
-assert_eq!(
-    bubblebabble::decode("xigak-nyryk-humil-bosek-sonax"),
-    Ok(Vec::from(&b"Pineapple"[..]))
-);
+assert_eq!(bubblebabble::encode("Pineapple"), "xigak-nyryk-humil-bosek-sonax");
+assert_eq!(bubblebabble::decode(b"xexax"), Ok(vec![]));
 ```
+
+## Crate Features
+
+`bubblebabble` has a `std` feature which is enabled by default that adds `Vec`
+and `String` support as well as `std::error::Error` impls. `bubblebabble` does
+not compile if this feature is disabled, but exists so this crate can add
+`no_std` support backwards compatibly.
+
+`bubblebabble` is [fuzzed](/fuzz/fuzz_targets) with
+[cargo-fuzz](https://crates.io/crates/cargo-fuzz).
+
+## Minimum Rust Version Policy
+
+This crate's minimum supported `rustc` version (MSRV) is `1.42.0`.
+
+MSRV may be bumped in minor version releases.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
 #![allow(clippy::cast_possible_truncation)]
-#![deny(clippy::cargo)]
-#![deny(missing_docs, intra_doc_link_resolution_failure)]
+#![warn(clippy::cargo)]
+#![warn(missing_docs, intra_doc_link_resolution_failure)]
+#![warn(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
 
 //! # bubblebabble
@@ -55,6 +56,11 @@
 //! `bubble-babble-ts` is licensed under the
 //! [MIT License](https://github.com/JonathanWilbur/bubble-babble-ts/blob/v1.0.1/LICENSE.txt)
 //! Copyright (c) 2018 Jonathan M. Wilbur \<jonathan@wilbur.space\>.
+
+#![doc(html_root_url = "https://artichoke.github.io/bubblebabble")]
+
+#[cfg(doctest)]
+doc_comment::doctest!("../README.md");
 
 use bstr::ByteSlice;
 use std::error;

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -1,0 +1,10 @@
+#[test]
+fn test_readme_deps() {
+    version_sync::assert_markdown_deps_updated!("README.md");
+}
+
+#[test]
+#[should_panic] // Not supported yet since not on crates.io
+fn test_html_root_url() {
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
+}


### PR DESCRIPTION
- Add `homepage` to `Cargo.toml`.
- Tweak `Cargo.toml` keywords inspired by `base64`.
- Add `doc-comment` tests for code in `README.md`.
- Add `version-sync` tests for `README.md` and `doc_html_root`.
- Tweak master docs README badge to clarify that they are HEAD docs.
- Tweak README intro to match `rand_mt`: high-level description +
  summary of the algorithm.
- Add usage information and example of encode and decode to README.
- Remove test vectors from README.
- Document `std` feature.
- Document MSRV = 1.42.0 (subslice patterns).
- Change `deny` pragmas to `warn` in `lib.rs`.
- Add `warn(missing_debug_implementations)`.
- Remove license information from crate-level documentation.