### PR TITLE
Add an optional feature 'std'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,16 @@ description = "Encoder and decoder for the Bubble Babble binary data encoding"
 keywords = ["encode", "decode", "utf8", "bubblebabble"]
 categories = ["encoding"]
 
+[features]
+default = ["std"]
+# Enable dependency on the Rust standard library.
+#
+# This feature exists to support the possiblity that `bubblebabble` may
+# eventually support compiling in `no_std` environments.
+#
+# Currently, this feature is required to build `bubblebabble`.
+std = ["bstr/std"]
+
 [dependencies]
 bstr = { version = "0.2", default-features = false }
 


### PR DESCRIPTION
This feature enables adding 'no_std' support in a backwards
compatible way.