### PR TITLE
Add a (unenforced) CI job for testing `boba` with MSRV Rust 1.42.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,44 @@ jobs:
           # known failing since boba requires the alloc feature to build
           cargo test --no-default-features || :
 
+  build-msrv:
+    name: Build (1.42.0)
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: "1.42.0"
+          profile: minimal
+
+      - name: Compile
+        run: cargo build --verbose
+
+      - name: Compile tests
+        run: cargo test --no-run
+
+      - name: Test
+        run: cargo test
+
+      - name: Test with all features
+        run: cargo test --all-features
+
+      - name: Test with only alloc feature
+        shell: bash
+        run: cargo test --no-default-features --features alloc
+
+      - name: Test with no default features
+        shell: bash
+        run: |
+          # known failing since boba requires the alloc feature to build
+          cargo test --no-default-features || :
+
   rust:
     name: Lint and format Rust
     runs-on: ubuntu-latest


### PR DESCRIPTION
The build is not blocking, but will ensure that changes to the MSRV are made consciously.