### PR TITLE
Prepare for v4.1.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boba"
-version = "4.1.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "4.1.1" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"
@@ -34,3 +34,8 @@ bstr = { version = "0.2", default-features = false }
 [dev-dependencies]
 bubblebabble = "0.1"
 version-sync = "0.9"
+
+[package.metadata.docs.rs]
+# This sets the default target to `x86_64-unknown-linux-gnu` and only builds
+# that target. `boba` has the same API and code on all targets.
+targets = ["x86_64-unknown-linux-gnu"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@
 //! [`std`]: https://doc.rust-lang.org/stable/std/index.html
 //! [`std::error::Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 
-#![doc(html_root_url = "https://docs.rs/boba/4.1.0")]
+#![doc(html_root_url = "https://docs.rs/boba/4.1.1")]
 // Without the `std` feature, build `boba` with `no_std`.
 #![cfg_attr(not(feature = "std"), no_std)]
 


### PR DESCRIPTION
Release `boba` 4.1.1.

[`boba` is published on crates.io](https://crates.io/crates/boba/4.1.1).

This release contains enhancements:

- Avoid `write!` macro in `fmt::Display` impl for `DecodeError`. https://github.com/artichoke/boba/pull/62
- Add additional tests for bytes outside of the encoding alphabet. https://github.com/artichoke/boba/pull/63
- Add a (unenforced) CI job for testing `boba` with MSRV Rust 1.42.0. https://github.com/artichoke/boba/pull/64

This release contains improvements to documentation and build process.