### PR TITLE
Prepare v4.1.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boba"
-version = "4.1.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "4.1.2" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@
 //! [`std`]: https://doc.rust-lang.org/stable/std/index.html
 //! [`std::error::Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 
-#![doc(html_root_url = "https://docs.rs/boba/4.1.1")]
+#![doc(html_root_url = "https://docs.rs/boba/4.1.2")]
 // Without the `std` feature, build `boba` with `no_std`.
 #![cfg_attr(not(feature = "std"), no_std)]
 


### PR DESCRIPTION
Release `boba` 4.1.2.

[`boba` is published on crates.io](https://crates.io/crates/boba/4.1.2).

This release contains internal code quality improvements: #66, #67.