### PR TITLE
Fix bstr dependency to properly declare minimal version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,28 @@ jobs:
           # known failing since boba requires the alloc feature to build
           cargo test --no-default-features || :
 
+  rust-minimal-versions:
+    name: Compile with minimum dependency versions
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          profile: minimal
+
+      - name: Check with minimal versions
+        run: |
+          cargo generate-lockfile -Z minimal-versions
+          cargo check
+
   rust:
     name: Lint and format Rust
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ std = ["alloc"]
 alloc = []
 
 [dependencies]
-bstr = { version = "0.2", default-features = false }
+# `no_std` mode was fixed in https://github.com/BurntSushi/bstr/commit/83e8f27e
+bstr = { version = "0.2.4", default-features = false }
 
 [dev-dependencies]
 bubblebabble = "0.1"


### PR DESCRIPTION
Add a CI job to `cargo check` `boba` with its minimal dependency versions.