### PR TITLE
Prepare for v4.2.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boba"
-version = "4.1.2" # remember to set `html_root_url` in `src/lib.rs`.
+version = "4.2.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-boba = "4"
+boba = "4.2"
 ```
 
 Then encode and decode data like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //! [`std::error::Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/boba/4.1.2")]
+#![doc(html_root_url = "https://docs.rs/boba/4.2.0")]
 
 // Without the `alloc` feature, build `boba` without alloc.
 // This configuration is unsupported and will result in a compile error.


### PR DESCRIPTION
Release `boba` 4.2.0.

[`boba` is published on crates.io](https://crates.io/crates/boba/4.2.0).

This release fixes a bug in `boba`'s minimal dependency declaration for `bstr`. #71 

Updating the version of `boba` you depend on to `4.2` will allow `boba` to build when generating a lockfile with minimal depdenency versions, e.g.

```shell
cargo +nightly generate-lockfile -Z minimal-versions
```

Declare `boba` in `Cargo.toml` like:

```toml
[dependencies]
boba = "4.2"
```