### PR TITLE
Require version-sync at least 0.9.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,11 @@ alloc = []
 bstr = { version = "0.2.4", default-features = false }
 
 [dev-dependencies]
+# Alternative algorthim implementation for bench comparisons.
 bubblebabble = "0.1"
-version-sync = "0.9"
+# Check that crate versions are properly updated in documentation and code when
+# bumping the version.
+version-sync = "0.9, >= 0.9.2"
 
 [package.metadata.docs.rs]
 # This sets the default target to `x86_64-unknown-linux-gnu` and only builds


### PR DESCRIPTION
This fixes some warnings on current nightly related to panic formatting.