### PR TITLE
Update devtools Rakefile clippy invocation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,10 +14,7 @@ namespace :lint do
 
   desc 'Lint Rust sources with Clippy'
   task :clippy do
-    FileList['**/{build,lib,main}.rs'].each do |root|
-      FileUtils.touch(root)
-    end
-    sh 'cargo clippy --workspace --all-features'
+    sh 'cargo clippy --workspace --all-features --all-targets'
   end
 
   desc 'Lint Rust sources with Clippy restriction pass (unenforced lints)'


### PR DESCRIPTION
- Pass `--all-targets` to match CI
- Remove touch command for entrypoints which was made unnecessary in Rust 1.52.0