### PR TITLE
Scope encoded length to block for constructing the decode buffer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,8 +278,10 @@ pub fn decode<T: AsRef<[u8]>>(encoded: T) -> Result<Vec<u8>, DecodeError> {
         // header byte.
         return Err(DecodeError::InvalidByte(pos + 1));
     }
-    let len = encoded.len();
-    let mut decoded = Vec::with_capacity(if len == 5 { 1 } else { 2 * ((len + 1) / 6) });
+    let mut decoded = {
+        let len = encoded.len();
+        Vec::with_capacity(if len == 5 { 1 } else { 2 * ((len + 1) / 6) })
+    };
     let mut checksum = 1_u8;
     let mut chunks = enc.chunks_exact(6);
     while let Some(&[left, mid, right, up, b'-', down]) = chunks.next() {


### PR DESCRIPTION
`boba::decode` eagerly allocates a `Vec` for output with
`Vec::with_capacity` using the length of the encoded input. To avoid
calling `encoded.len()` twice in the capacity computation, it is stored
in a `len` binding.

This binding is otherwise unused. Scoping the binding to a block for its
single use makes the intent clearer and prevents the variable from
accidentaly being used later.