### PR TITLE
Update Cargo.toml manifest version and docs.rs metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,6 @@ features = ["markdown_deps_updated", "html_root_url_updated"]
 [package.metadata.docs.rs]
 # This sets the default target to `x86_64-unknown-linux-gnu` and only builds
 # that target. `boba` has the same API and code on all targets.
-targets = ["x86_64-unknown-linux-gnu"]
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,12 @@
 #![warn(unused_qualifications)]
 #![warn(variant_size_differences)]
 #![forbid(unsafe_code)]
+// Enable feature callouts in generated documentation:
+// https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
+//
+// This approach is borrowed from tokio.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
 
 //! This crate provides an implementation of a Bubble Babble encoder and
 //! decoder.


### PR DESCRIPTION
- Use precise versions for dependencies. See: https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277
- Use the same style of docs.rs metadata as used in artichoke/raw-parts#24.
- Enable `doc_cfg` and `doc_alias` features when `docsrs` cfg is passed during compilation.

See:

- https://github.com/artichoke/rand_mt/pull/125