### PR TITLE
Optimize `encode` for empty input by hardcoding the result

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,10 @@ impl fmt::Display for DecodeError {
 #[must_use]
 pub fn encode<T: AsRef<[u8]>>(data: T) -> String {
     let data = data.as_ref();
+    if data.is_empty() {
+        return String::from("xexax");
+    }
+
     let mut encoded = String::with_capacity(6 * (data.len() / 2) + 3 + 2);
     encoded.push(HEADER.into());
     let mut checksum = 1_u8;


### PR DESCRIPTION
## Benches

```
boba::encode/empty      time:   [45.861 ns 46.337 ns 46.890 ns]
                        change: [-15.461% -13.929% -12.685%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
boba::encode/1234567890 time:   [93.673 ns 94.156 ns 94.667 ns]
                        change: [-2.8358% -0.9728% +0.8215%] (p = 0.33 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
boba::encode/Pineapple  time:   [90.281 ns 90.577 ns 90.895 ns]
                        change: [+0.2774% +1.5987% +2.9150%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
boba::encode/emoji      time:   [146.38 ns 146.92 ns 147.50 ns]
                        change: [-1.2052% -0.0792% +1.2912%] (p = 0.92 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
```