### PR TITLE
Optimize `boba::decode`

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,7 +1,12 @@
 #[cfg(feature = "alloc")]
 use alloc::string::String;
 
-use crate::{CONSONANTS, HEADER, TRAILER, VOWELS};
+const VOWELS: [u8; 6] = *b"aeiouy";
+const CONSONANTS: [u8; 16] = *b"bcdfghklmnprstvz";
+const HEADER: &str = "x";
+const TRAILER: &str = "x";
+const SEPARATOR: &str = "-";
+const MID: &str = "x";
 
 #[must_use]
 pub fn inner(data: &[u8]) -> String {
@@ -10,7 +15,7 @@ pub fn inner(data: &[u8]) -> String {
     }
 
     let mut encoded = String::with_capacity(6 * (data.len() / 2) + 3 + 2);
-    encoded.push(HEADER.into());
+    encoded.push_str(HEADER);
     let mut checksum = 1_u8;
     let mut chunks = data.chunks_exact(2);
     while let Some(&[left, right]) = chunks.next() {
@@ -23,7 +28,7 @@ pub fn inner(data: &[u8]) -> String {
         // - `CONSONANTS` is a fixed size array with 16 elements.
         // - Maximum value of `d` is 15.
         encoded.push(CONSONANTS[d as usize].into());
-        encoded.push('-');
+        encoded.push_str(SEPARATOR);
         // Panic safety:
         //
         // - `e` is constructed with a mask of `0b1111`.
@@ -37,7 +42,7 @@ pub fn inner(data: &[u8]) -> String {
     } else {
         even_partial(checksum, &mut encoded);
     }
-    encoded.push(TRAILER.into());
+    encoded.push_str(TRAILER);
     encoded
 }
 
@@ -77,7 +82,7 @@ fn even_partial(checksum: u8, buf: &mut String) {
     // - `VOWELS` is a fixed size array with 6 elements.
     // - Maximum value of `a` is 5.
     buf.push(VOWELS[a as usize].into());
-    buf.push('x');
+    buf.push_str(MID);
     // Panic safety:
     //
     // - `c` is constructed with divide by 6.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,13 +110,6 @@ use core::fmt;
 mod decode;
 mod encode;
 
-const VOWELS: [u8; 6] = *b"aeiouy";
-const CONSONANTS: [u8; 16] = *b"bcdfghklmnprstvz";
-const ALPHABET: [u8; 24] = *b"aeiouybcdfghklmnprstvzx-";
-
-const HEADER: u8 = b'x';
-const TRAILER: u8 = b'x';
-
 /// Decoding errors from [`boba::decode`](decode()).
 ///
 /// `decode` will return a `DecodeError` if:


### PR DESCRIPTION
Replace casting in and out of `usize` and `u8` with lookup functions
from alphabet to `Option<u8>`. This speeds up `decode` performance by
40%.

I tried a similar approach with the inverse lookup functions in
`encode`, but it ended up regressing performance. I also tried turning
the `VOWELS` and `CONSONANTS` byte arrays into `&str` and using string
slicing + `Vec::push_str`, which also was a perf regression, though not
as terrible.

This change moves the constants to the impls that use them.

## Benches

```
boba::encode/empty      time:   [47.172 ns 47.367 ns 47.624 ns]
                        change: [-2.9934% -1.3885% +0.1573%] (p = 0.09 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
boba::encode/1234567890 time:   [91.299 ns 92.079 ns 93.259 ns]
                        change: [-3.7216% -1.4479% +0.6579%] (p = 0.23 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
boba::encode/Pineapple  time:   [88.381 ns 88.620 ns 88.878 ns]
                        change: [-1.4140% +0.2051% +1.7561%] (p = 0.82 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe
boba::encode/emoji      time:   [143.71 ns 144.28 ns 144.85 ns]
                        change: [-3.1676% -1.5487% +0.2036%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

boba::decode/empty      time:   [2.6613 ns 2.6754 ns 2.6922 ns]
                        change: [-1.7823% +0.0568% +2.0069%] (p = 0.95 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  5 (5.00%) high severe
boba::decode/1234567890 time:   [110.56 ns 110.95 ns 111.37 ns]
                        change: [-36.386% -35.402% -34.381%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
boba::decode/Pineapple  time:   [104.09 ns 104.45 ns 104.84 ns]
                        change: [-34.155% -33.331% -32.503%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
boba::decode/emoji      time:   [170.75 ns 171.32 ns 172.09 ns]
                        change: [-40.980% -40.013% -38.925%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  8 (8.00%) high severe
```