### PR TITLE
Update docs, prepare for v4.3.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boba"
-version = "4.2.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "4.3.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-boba = "4.2.0"
+boba = "4.3.0"
 ```
 
 Then encode and decode data like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,8 @@
 //! encode binary data to pseudowords that can be pronounced more easily than
 //! arbitrary lists of hexadecimal digits.
 //!
-//! Bubble Babble is part of the Digest libraries in Perl and Ruby.
+//! Bubble Babble is part of the Digest libraries in [Perl][perl-bubblebabble]
+//! and [Ruby][ruby-bubblebabble].
 //!
 //! # Usage
 //!
@@ -74,11 +75,13 @@
 //!   collections library. Currently, Boba requires this feature to build, but
 //!   may relax this requirement in the future.
 //!
+//! [perl-bubblebabble]: https://metacpan.org/pod/Digest::BubbleBabble
+//! [ruby-bubblebabble]: https://ruby-doc.org/stdlib-3.1.1/libdoc/digest/rdoc/Digest.html#method-c-bubblebabble
 //! [`std`]: https://doc.rust-lang.org/stable/std/index.html
 //! [`std::error::Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/boba/4.2.0")]
+#![doc(html_root_url = "https://docs.rs/boba/4.3.0")]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]
@@ -114,12 +117,12 @@ mod encode;
 ///
 /// `decode` will return a `DecodeError` if:
 ///
-/// - The input is not an ASCII string, an error is returned.
+/// - The input is not an ASCII string.
 /// - The input contains an ASCII character outside of the Bubble Babble
-///   encoding alphabet, an error is returned.
-/// - The input does not start with a leading 'x', an error is returned.
-/// - The input does not end with a trailing 'x', an error is returned.
-/// - The decoded result does not checksum properly, an error is returned.
+///   encoding alphabet.
+/// - The input does not start with a leading 'x'.
+/// - The input does not end with a trailing 'x'.
+/// - The decoded result does not checksum properly.
 ///
 /// # Examples
 ///
@@ -207,12 +210,12 @@ pub fn encode<T: AsRef<[u8]>>(data: T) -> String {
 ///
 /// Decoding is fallible and might return [`DecodeError`] if:
 ///
-/// - The input is not an ASCII string, an error is returned.
+/// - The input is not an ASCII string.
 /// - The input contains an ASCII character outside of the Bubble Babble
-///   encoding alphabet, an error is returned.
-/// - The input does not start with a leading 'x', an error is returned.
-/// - The input does not end with a trailing 'x', an error is returned.
-/// - The decoded result does not checksum properly, an error is returned.
+///   encoding alphabet.
+/// - The input does not start with a leading 'x'.
+/// - The input does not end with a trailing 'x'.
+/// - The decoded result does not checksum properly.
 ///
 /// ```
 /// # use boba::DecodeError;


### PR DESCRIPTION
Release `boba` 4.3.0

[`boba` is published on crates.io](https://crates.io/crates/boba/4.3.0).

This release contains enhancements and performance optimizations. `boba::decode` is 35% faster than v4.2.0.

- Optimize encode for empty input by hardcoding the result. https://github.com/artichoke/boba/pull/135
- Minimize codebloat by moving encoder and decoder out of generic function. https://github.com/artichoke/boba/pull/136
- Optimize `boba::decode`. https://github.com/artichoke/boba/pull/137
- Remove `bstr` dependency and reimplement bits that are used in decode. https://github.com/artichoke/boba/pull/138

Improvements to dev dependencies and benchmark tooling:

- Update version-sync to 0.9.3 and trim some deps from Cargo.lock. https://github.com/artichoke/boba/pull/117
- Remove comparison benches with alternate implementation. https://github.com/artichoke/boba/pull/123
- Migrate benches to subcrate with criterion, remove nightly toolchain dep. https://github.com/artichoke/boba/pull/134

This release also includes several code quality improvements:

- Scope encoded length to block for constructing the decode buffer. https://github.com/artichoke/boba/pull/103
- Format use import statements to have groups for core + other deps. https://github.com/artichoke/boba/pull/104

This release contains improvements to documentation and build process.