### PR TITLE
Remove notice from README on derived work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boba"
-version = "4.3.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "4.3.1" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -57,12 +57,6 @@ MSRV may be bumped in minor version releases.
 
 `boba` is licensed under the [MIT License](LICENSE) (c) Ryan Lopopolo.
 
-`boba` is derived from `bubble-babble-ts` @
-[v1.0.1](https://github.com/JonathanWilbur/bubble-babble-ts/tree/v1.0.1).
-`bubble-babble-ts` is licensed under the
-[MIT License](https://github.com/JonathanWilbur/bubble-babble-ts/blob/v1.0.1/LICENSE.txt)
-Copyright (c) 2018 Jonathan M. Wilbur \<jonathan@wilbur.space\>.
-
 [bubble-babble-spec]: spec/Bubble_Babble_Encoding.txt
 [`alloc`]: https://doc.rust-lang.org/stable/alloc/index.html
 [`std`]: https://doc.rust-lang.org/stable/std/index.html

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-boba = "4.3.0"
+boba = "4.3.1"
 ```
 
 Then encode and decode data like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 //! [`std::error::Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/boba/4.3.0")]
+#![doc(html_root_url = "https://docs.rs/boba/4.3.1")]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]


### PR DESCRIPTION
With v4.3.0, none of the original algorithms and approach from the referenced implementation are in use.