### PR TITLE
chore: Update `.github/workflows/rustdoc.yaml` in `artichoke/boba`

### DIFF
--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -42,14 +42,6 @@ jobs:
           cargo version --verbose
           echo "::endgroup::"
 
-      - name: Generate Cargo.lock
-        run: |
-          if [[ ! -f "Cargo.lock" ]]; then
-            cargo generate-lockfile --verbose
-          fi
-
-      - uses: Swatinem/rust-cache@v1
-
       - name: Build Documentation
         run: cargo doc --workspace
 

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -21,17 +21,41 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
+      - name: Install nightly Rust toolchain
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install nightly --profile minimal
+          echo "::endgroup::"
+          echo "::group::set default toolchain"
+          rm -rf rust-toolchain
+          rustup default nightly
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
+
+      - name: Generate Cargo.lock
+        run: |
+          if [[ ! -f "Cargo.lock" ]]; then
+            cargo generate-lockfile --verbose
+          fi
+
+      - uses: Swatinem/rust-cache@v1
 
       - name: Build Documentation
-        run: cargo doc
+        run: cargo doc --workspace
+
+      # https://github.com/artichoke/artichoke/issues/1826
+      - name: Purge sources from out dir
+        run: find . -path './target/doc/*/target/debug/build/*' | xargs rm -rf
 
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3
@@ -42,3 +66,6 @@ jobs:
           publish_branch: gh-pages
           user_name: artichoke-ci
           user_email: ci@artichokeruby.org
+          # only have the most recent docs in the `gh-pages` branch
+          # https://github.com/artichoke/artichoke/issues/1826
+          force_orphan: true


### PR DESCRIPTION
Managed by Terraform.

See:

- https://github.com/artichoke/artichoke/issues/1826

## Contents

```
---
name: Documentation
"on":
  push:
    branches:
      - trunk
  pull_request:
    branches:
      - trunk
  schedule:
    - cron: "0 0 * * TUE"
concurrency:
  group: docs-${{ github.head_ref }}
jobs:
  rustdoc:
    name: Build Rust API docs
    runs-on: ubuntu-latest
    env:
      RUSTDOCFLAGS: -D warnings -D rustdoc::broken_intra_doc_links --cfg docsrs
      RUST_BACKTRACE: 1

    steps:
      - name: Checkout repository
        uses: actions/checkout@v3

      - name: Install nightly Rust toolchain
        run: |
          echo "::group::rustup toolchain install"
          rustup toolchain install nightly --profile minimal
          echo "::endgroup::"
          echo "::group::set default toolchain"
          rm -rf rust-toolchain
          rustup default nightly
          echo "::endgroup::"
          echo "::group::rustup version"
          rustup -Vv
          echo "::endgroup::"
          echo "::group::rustc version"
          rustc -Vv
          echo "::endgroup::"
          echo "::group::cargo version"
          cargo version --verbose
          echo "::endgroup::"

      - name: Generate Cargo.lock
        run: |
          if [[ ! -f "Cargo.lock" ]]; then
            cargo generate-lockfile --verbose
          fi

      - uses: Swatinem/rust-cache@v1

      - name: Build Documentation
        run: cargo doc --workspace

      # https://github.com/artichoke/artichoke/issues/1826
      - name: Purge sources from out dir
        run: find . -path './target/doc/*/target/debug/build/*' | xargs rm -rf

      - name: Deploy Docs
        uses: peaceiris/actions-gh-pages@v3
        if: github.ref == 'refs/heads/trunk'
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          publish_dir: ./target/doc
          publish_branch: gh-pages
          user_name: artichoke-ci
          user_email: ci@artichokeruby.org
          # only have the most recent docs in the `gh-pages` branch
          # https://github.com/artichoke/artichoke/issues/1826
          force_orphan: true
```