### PR TITLE
Remove `alloc` feature

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,15 +42,8 @@ jobs:
       - name: Test with all features
         run: cargo test --all-features
 
-      - name: Test with only alloc feature
-        shell: bash
-        run: cargo test --no-default-features --features alloc
-
       - name: Test with no default features
-        shell: bash
-        run: |
-          # known failing since boba requires the alloc feature to build
-          cargo test --no-default-features || :
+        run: cargo test --no-default-features
 
   build-msrv:
     name: Build (1.42.0)
@@ -80,15 +73,8 @@ jobs:
       - name: Test with all features
         run: cargo test --all-features
 
-      - name: Test with only alloc feature
-        shell: bash
-        run: cargo test --no-default-features --features alloc
-
       - name: Test with no default features
-        shell: bash
-        run: |
-          # known failing since boba requires the alloc feature to build
-          cargo test --no-default-features || :
+        run: cargo test --no-default-features
 
   rust-minimal-versions:
     name: Compile with minimum dependency versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,7 @@ include = ["src/**/*", "tests/**/*", "LICENSE", "README.md"]
 default = ["std"]
 # Enable dependency on `std`, the Rust standard library. This feature enables
 # `std::error::Error` implementations on the error types in `boba`.
-std = ["alloc"]
-# Enable a dependency on the `alloc` crate. This feature grants `boba` access to
-# the `Vec` and `String` types. This feature is currently required to build
-# `boba`, but exists to enable adding a slice-based, no allocator API in a
-# backwards-compatible way.
-alloc = []
+std = []
 
 [dependencies]
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ Boba has several Cargo features, all of which are enabled by default:
 - **std** - Adds a dependency on [`std`], the Rust Standard Library. This
   feature enables [`std::error::Error`] implementations on error types in this
   crate. Enabling the **std** feature also enables the **alloc** feature.
-- **alloc** - Adds a dependency on [`alloc`], the Rust allocation and
-  collections library. Currently, Boba requires this feature to build, but may
-  relax this requirement in the future.
 
 `boba` is [fuzzed](fuzz/fuzz_targets) with [cargo-fuzz].
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 use crate::DecodeError;

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "alloc")]
 use alloc::string::String;
 
 const VOWELS: [u8; 6] = *b"aeiouy";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,6 @@
 //!   feature enables [`std::error::Error`] implementations on error types in
 //!   this crate. Enabling the **std** feature also enables the **alloc**
 //!   feature.
-//! - **alloc** - Adds a dependency on [`alloc`], the Rust allocation and
-//!   collections library. Currently, Boba requires this feature to build, but
-//!   may relax this requirement in the future.
 //!
 //! [perl-bubblebabble]: https://metacpan.org/pod/Digest::BubbleBabble
 //! [ruby-bubblebabble]: https://ruby-doc.org/stdlib-3.1.1/libdoc/digest/rdoc/Digest.html#method-c-bubblebabble
@@ -94,19 +91,14 @@ macro_rules! readme {
         readme!(include_str!("../README.md"));
     };
 }
-#[cfg(all(feature = "alloc", doctest))]
+#[cfg(doctest)]
 readme!();
 
-// Without the `alloc` feature, build `boba` without alloc.
-// This configuration is unsupported and will result in a compile error.
-#[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-#[cfg(feature = "alloc")]
 use alloc::string::String;
-#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 use core::fmt;
 


### PR DESCRIPTION
`boba` has a required dependency on the `alloc` crate, but gates the
availability of the `alloc` crate with the `alloc` feature.

`boba` does not build with no default features as a result. The docs
lead me to believe this was intentional, but with new CI steps in #159,
all Artichoke crates must build and pass a docs build with no default
features.

This will require a semver major bump.