### PR TITLE
Prepare for 5.0.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boba"
-version = "4.3.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "5.0.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-boba = "4.3.1"
+boba = "5.0.0"
 ```
 
 Then encode and decode data like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,13 +72,19 @@
 //!   this crate. Enabling the **std** feature also enables the **alloc**
 //!   feature.
 //!
+#![cfg_attr(
+    not(feature = "std"),
+    doc = "[`std`]: https://doc.rust-lang.org/stable/std/index.html"
+)]
+#![cfg_attr(
+    not(feature = "std"),
+    doc = "[`std::error::Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html"
+)]
 //! [perl-bubblebabble]: https://metacpan.org/pod/Digest::BubbleBabble
 //! [ruby-bubblebabble]: https://ruby-doc.org/stdlib-3.1.1/libdoc/digest/rdoc/Digest.html#method-c-bubblebabble
-//! [`std`]: https://doc.rust-lang.org/stable/std/index.html
-//! [`std::error::Error`]: https://doc.rust-lang.org/stable/std/error/trait.Error.html
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/boba/4.3.1")]
+#![doc(html_root_url = "https://docs.rs/boba/5.0.0")]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]


### PR DESCRIPTION


Release 5.0.0 of `boba`.

[`boba` is published on crates.io](https://crates.io/crates/boba/5.0.0).

## Breaking changes

- Remove `alloc` feature. `boba` has a required dependency on the `alloc` crate, but gates the availability of the `alloc` crate with the alloc feature. `boba` 4.x did not build when compiling with `--no-default-features`. Make `alloc` a non-optional dependency. https://github.com/artichoke/boba/pull/160

## Testing improvements

- Add a test that the `impl Display for DecodeError` is non-empty. https://github.com/artichoke/boba/pull/157

## Documentation improvements

- Ensure documentation builds without intradoc link errors when compiling without default features. https://github.com/artichoke/boba/pull/160
- Avoid hardcoding links to `std` docs when the `std` feature is enabled. https://github.com/artichoke/boba/pull/161