### PR TITLE
Fix glob to allow vendor/README.md to be linted for markdown links

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -95,7 +95,7 @@ namespace :release do
   link_check_files = FileList.new('**/*.md') do |f|
     f.exclude('node_modules/**/*')
     f.exclude('**/target/**/*')
-    f.exclude('**/vendor/**/*')
+    f.exclude('**/vendor/*/**/*')
     f.include('*.md')
     f.include('**/vendor/*.md')
   end


### PR DESCRIPTION
See https://github.com/artichoke/strftime-ruby/pull/59.