### PR TITLE
Remove actions-rs GitHub Actions

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -22,11 +22,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: stable
-          profile: minimal
-          override: true
 
       - name: Compile
         run: cargo build --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,10 +25,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: stable
-          profile: minimal
 
       - name: Compile
         run: cargo build --verbose
@@ -56,11 +55,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: "1.42.0"
-          profile: minimal
-          override: true
 
       - name: Compile
         run: cargo build --verbose
@@ -92,17 +89,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Rust nightly toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: artichoke/setup-rust/check-minimal-versions@v1
         with:
-          toolchain: nightly
-          override: true
-          profile: minimal
+          toolchain: stable
+
+      - name: Generate minimal versions lockfile
+        run: cargo +nightly generate-lockfile -Z minimal-versions
 
       - name: Check with minimal versions
-        run: |
-          cargo generate-lockfile -Z minimal-versions
-          cargo check
+        run: cargo check --all-targets --profile=test
 
   rust:
     name: Lint and format Rust
@@ -115,21 +111,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/lint-and-format@v1
         with:
           toolchain: stable
-          override: true
-          profile: minimal
-          components: rustfmt, clippy
 
       - name: Check formatting
-        run: cargo fmt -- --check --color=auto
+        run: cargo fmt --check
 
       - name: Lint with Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets
+        run: cargo clippy --workspace --all-features --all-targets
 
   ruby:
     name: Lint and format Ruby

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -15,11 +15,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: nightly
-          profile: minimal
-          override: true
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
@@ -38,11 +36,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: nightly
-          profile: minimal
-          override: true
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
@@ -61,11 +57,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
           toolchain: nightly
-          profile: minimal
-          override: true
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz


### PR DESCRIPTION
GitHub is deprecating the node 12 runtime for GitHub Actions. actions-rs/toolchain and actions-rs/clippy are unmaintained and currently emit warnings due to the deprecation.

Replace these with actions from https://github.com/artichoke/setup-rust.

Audit and rustdoc workflows are not updated since these are managed by Terraform in artichoke/project-infrastructure.