### PR TITLE
chore: Update `.github/workflows/rustdoc.yaml` in `artichoke/boba`

### DIFF
--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -23,24 +23,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install nightly Rust toolchain
-        run: |
-          echo "::group::rustup toolchain install"
-          rustup toolchain install nightly --profile minimal
-          echo "::endgroup::"
-          echo "::group::set default toolchain"
-          rm -rf rust-toolchain
-          rustup default nightly
-          echo "::endgroup::"
-          echo "::group::rustup version"
-          rustup -Vv
-          echo "::endgroup::"
-          echo "::group::rustc version"
-          rustc -Vv
-          echo "::endgroup::"
-          echo "::group::cargo version"
-          cargo version --verbose
-          echo "::endgroup::"
+      - name: Install Rust toolchain
+        uses: artichoke/setup-rust/rustdoc@v1
 
       - name: Check docs with no default features
         run: cargo doc --workspace --no-default-features
@@ -50,10 +34,6 @@ jobs:
 
       - name: Build Documentation
         run: cargo doc --workspace
-
-      # https://github.com/artichoke/artichoke/issues/1826
-      - name: Purge sources from out dir
-        run: find . -path './target/doc/*/target/debug/build/*' | xargs rm -rf
 
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Managed by Terraform.

## Contents

```
---
name: Documentation
"on":
  push:
    branches:
      - trunk
  pull_request:
    branches:
      - trunk
  schedule:
    - cron: "0 0 * * TUE"
concurrency:
  group: docs-${{ github.head_ref }}
jobs:
  rustdoc:
    name: Build Rust API docs
    runs-on: ubuntu-latest
    env:
      RUSTDOCFLAGS: -D warnings -D rustdoc::broken_intra_doc_links --cfg docsrs
      RUST_BACKTRACE: 1

    steps:
      - name: Checkout repository
        uses: actions/checkout@v3

      - name: Install Rust toolchain
        uses: artichoke/setup-rust/rustdoc@v1

      - name: Check docs with no default features
        run: cargo doc --workspace --no-default-features

      - name: Clean docs
        run: cargo clean

      - name: Build Documentation
        run: cargo doc --workspace

      - name: Deploy Docs
        uses: peaceiris/actions-gh-pages@v3
        if: github.ref == 'refs/heads/trunk'
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          publish_dir: ./target/doc
          publish_branch: gh-pages
          user_name: artichoke-ci
          user_email: ci@artichokeruby.org
          # only have the most recent docs in the `gh-pages` branch
          # https://github.com/artichoke/artichoke/issues/1826
          force_orphan: true
```