### PR TITLE
Set `rust-version` in `Cargo.toml` to 1.42.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "5.0.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"
+rust-version = "1.42.0"
 readme = "README.md"
 repository = "https://github.com/artichoke/boba"
 documentation = "https://docs.rs/boba"


### PR DESCRIPTION
This allows clippy to detect this crate's MSRV so the `clippy::uninlined_format_args` does not trigger.